### PR TITLE
Align logV clamps

### DIFF
--- a/single_asset/GBM/loss.py
+++ b/single_asset/GBM/loss.py
@@ -36,7 +36,7 @@ def compute_loss(model, batch, data_dict=None):
 
     # Forward pass
     logV = model(x)
-    logV = torch.clamp(logV, min=-20.0, max=20.0)  # avoid exp overflow
+    logV = torch.clamp(logV, min=-15.0, max=15.0)  # avoid exp overflow
     V = torch.exp(logV)
 
 

--- a/single_asset/Heston/evaluate.py
+++ b/single_asset/Heston/evaluate.py
@@ -41,7 +41,7 @@ def compute_controls(model, t0, W_vals, v_vals, config):
     
     # Forward: predict logV, then exp with clamp
     logV = model(x)
-    logV = torch.clamp(logV, min=-20.0, max=20.0)
+    logV = torch.clamp(logV, min=-15.0, max=15.0)
     V = torch.exp(logV)
     
     # Derivatives of logV

--- a/single_asset/Heston/loss.py
+++ b/single_asset/Heston/loss.py
@@ -40,7 +40,7 @@ def compute_loss(model, batch, data_dict=None):
 
     # Model prediction: log V for numerical stability
     logV = model(x)
-    logV = torch.clamp(logV, min=-20.0, max=20.0)
+    logV = torch.clamp(logV, min=-15.0, max=15.0)
     V = torch.exp(logV)
 
     # Compute derivatives via autograd

--- a/single_asset/MJD/loss.py
+++ b/single_asset/MJD/loss.py
@@ -37,7 +37,7 @@ def compute_loss(model, batch, data_dict=None, num_jump_samples=10):
     logV, pi_hat, c_hat = model(x)
 
     # Clamp logV for stability
-    logV = torch.clamp(logV, min=-20.0, max=20.0)
+    logV = torch.clamp(logV, min=-15.0, max=15.0)
     V = torch.exp(logV)
 
     # Derivatives of V


### PR DESCRIPTION
## Summary
- use [-15, 15] clamp for logV in Heston loss and evaluation
- standardise clamp range in GBM and MJD losses
- confirm compute_jump_integral already uses [-15, 15]

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c10471a248332a9bd6d04822d9d6f