### PR TITLE
Handle gamma=1 in utility term

### DIFF
--- a/single_asset/Bates/loss.py
+++ b/single_asset/Bates/loss.py
@@ -74,7 +74,11 @@ def compute_loss(model, batch, data_dict=None, num_jump_samples=10):
     ).unsqueeze(1)
 
     # --- 7. Utility ---
-    utility = c_hat.pow(1.0 - gamma) / (1.0 - gamma)
+    # Use log utility when gamma is effectively 1
+    if abs(gamma - 1.0) < 1e-3:
+        utility = torch.log(c_hat)
+    else:
+        utility = c_hat.pow(1.0 - gamma) / (1.0 - gamma)
 
     # --- 8. Residual & Losses ---
     residual = (

--- a/single_asset/GBM/loss.py
+++ b/single_asset/GBM/loss.py
@@ -59,7 +59,11 @@ def compute_loss(model, batch, data_dict=None):
     # HJB residual
     drift_term     = (config["r"] * W + pi_star * (config["mu"] - config["r"]) - c_star) * V_W
     diffusion_term = 0.5 * (pi_star ** 2) * (config["sigma"] ** 2) * V_WW
-    utility_term   = c_star.pow(1.0 - config["gamma"]) / (1.0 - config["gamma"])
+    # Use log utility when gamma approaches 1
+    if abs(config["gamma"] - 1.0) < 1e-3:
+        utility_term = torch.log(c_star)
+    else:
+        utility_term = c_star.pow(1.0 - config["gamma"]) / (1.0 - config["gamma"])
     residual = (V_t 
                 + drift_term 
                 + diffusion_term 

--- a/single_asset/Heston/loss.py
+++ b/single_asset/Heston/loss.py
@@ -80,7 +80,11 @@ def compute_loss(model, batch, data_dict=None):
     diff_WW   = 0.5 * (pi_star ** 2) * v * V_WW
     diff_vv   = 0.5 * (xi ** 2) * v * V_vv
     cross     = pi_star * xi * corr * v * V_Wv
-    utility   = c_star.pow(1.0 - gamma) / (1.0 - gamma)
+    # Use log utility when gamma is close to 1
+    if abs(gamma - 1.0) < 1e-3:
+        utility = torch.log(c_star)
+    else:
+        utility = c_star.pow(1.0 - gamma) / (1.0 - gamma)
 
     residual = (
         V_t + drift_W + drift_v + diff_WW + diff_vv + cross + utility

--- a/single_asset/MJD/loss.py
+++ b/single_asset/MJD/loss.py
@@ -69,7 +69,11 @@ def compute_loss(model, batch, data_dict=None, num_jump_samples=10):
     ).unsqueeze(1)  # ensure shape (N, 1)
 
     # Utility term
-    utility_term = c_hat.pow(1.0 - gamma) / (1.0 - gamma)
+    # Use log consumption when gamma ~= 1 for numerical stability
+    if abs(gamma - 1.0) < 1e-3:
+        utility_term = torch.log(c_hat)
+    else:
+        utility_term = c_hat.pow(1.0 - gamma) / (1.0 - gamma)
 
     # Residual of the HJB equation
     residual = V_t + drift_term + diffusion_term + jump_term + utility_term - rho * V


### PR DESCRIPTION
## Summary
- handle gamma near 1 with log utility in all compute_loss functions

## Testing
- `python -m py_compile single_asset/Bates/loss.py single_asset/GBM/loss.py single_asset/Heston/loss.py single_asset/MJD/loss.py`

------
https://chatgpt.com/codex/tasks/task_e_685d2e2b08ac8332aef28240642ba97a